### PR TITLE
Implement Websocket backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,12 @@ serde_json = { version = "1.0.64", default-features = false, optional = true }
 stderrlog = { version = "0.5.1", optional = true }
 structopt = { version = "0.3.21", optional = true }
 url = { version = "2.2.2", optional = true }
+
 # async-tungstenite = { version = "0.13.1", features = [], optional = true }
 async-tungstenite = { version = "0.13.1", features = ["async-std-runtime"] }
+futures-channel = { version = "0.3.15", default-features = false, features = ["alloc"] }
+futures-util = { version = "0.3.15", default-features = false, features = ["sink"] }
+async-mutex = { version = "1.4.0" }
 
 [dev-dependencies]
 async-std = { version = "1.9.0", features = ["attributes"] }

--- a/src/rpc.rs
+++ b/src/rpc.rs
@@ -1,0 +1,70 @@
+use async_trait::async_trait;
+use frame_metadata::RuntimeMetadataPrefixed;
+use futures_lite::AsyncReadExt;
+use jsonrpc::serde_json::value::RawValue;
+pub use jsonrpc::{error, Error, Request, Response};
+
+use crate::{meta_ext::MetaExt, Backend, StorageKey};
+
+pub type RpcResult = Result<Vec<u8>, error::Error>;
+
+/// Rpc defines types of backends that are remote and talk JSONRpc
+#[async_trait]
+pub trait Rpc: Backend + Send + Sync {
+    async fn rpc(&self, method: &str, params: &[&str]) -> RpcResult;
+
+    fn convert_params(params: &[&str]) -> Vec<Box<RawValue>> {
+        params
+            .iter()
+            .map(|p| format!("\"{}\"", p))
+            .map(RawValue::from_string)
+            .map(Result::unwrap)
+            .collect::<Vec<_>>()
+    }
+}
+
+#[async_trait]
+impl<R: Rpc> Backend for R {
+    async fn query_bytes<K>(&self, key: K) -> crate::Result<Vec<u8>>
+    where
+        K: std::convert::TryInto<StorageKey, Error = crate::Error> + Send,
+    {
+        let key = key.try_into()?.to_string();
+        log::debug!("StorageKey encoded: {}", key);
+        self.rpc("state_getStorage", &[&key])
+            .await
+            // NOTE it could fail for more reasons
+            .map_err(|_| crate::Error::StorageKeyNotFound)
+    }
+
+    async fn submit<T>(&self, mut ext: T) -> crate::Result<()>
+    where
+        T: futures_lite::AsyncRead + Send + Unpin,
+    {
+        let mut extrinsic = vec![];
+        ext.read_to_end(&mut extrinsic)
+            .await
+            .map_err(|_| crate::Error::BadInput)?;
+        let extrinsic = format!("0x{}", hex::encode(&extrinsic));
+        log::debug!("Extrinsic: {}", extrinsic);
+
+        let res = self
+            .rpc("author_submitExtrinsic", &[&extrinsic])
+            .await
+            .map_err(|e| crate::Error::Node(e.to_string()))?;
+        log::debug!("Extrinsic {:x?}", res);
+        Ok(())
+    }
+
+    async fn metadata(&self) -> crate::Result<frame_metadata::RuntimeMetadataPrefixed> {
+        let meta = self
+            .rpc("state_getMetadata", &[])
+            .await
+            .map_err(|e| crate::Error::Node(e.to_string()))?;
+
+        let meta = RuntimeMetadataPrefixed::from_bytes(meta).map_err(|_| crate::Error::BadMetadata);
+        log::trace!("Metadata {:#?}", meta);
+        meta
+    }
+}
+

--- a/src/ws.rs
+++ b/src/ws.rs
@@ -1,38 +1,132 @@
-use async_std::net::TcpStream;
+use async_mutex::Mutex;
+use async_std::task;
 use async_trait::async_trait;
-use async_tungstenite::{async_std::connect_async, WebSocketStream};
+use async_tungstenite::tungstenite::{Error as WsError, Message};
+use futures_channel::oneshot;
+use futures_util::{
+    sink::{Sink, SinkExt},
+    stream::SplitSink,
+    Stream, StreamExt,
+};
+use jsonrpc::{
+    error::{result_to_response, standard_error, StandardError},
+    serde_json,
+};
+use std::{collections::BTreeMap, sync::Arc};
 
-pub struct Backend {
-    connection: WebSocketStream<TcpStream>,
+use crate::{
+    rpc::{self, Rpc, RpcResult},
+    Error,
+};
+
+type Id = u8;
+
+pub struct Backend<Tx> {
+    tx: Mutex<Tx>,
+    messages: Arc<Mutex<BTreeMap<Id, oneshot::Sender<rpc::Response>>>>,
 }
 
 #[async_trait]
-impl crate::Backend for Backend {
-    async fn query_raw<K>(&self, key: K) -> crate::Result<Vec<u8>>
-    where
-        K: std::convert::TryInto<crate::StorageKey, Error = crate::Error> + Send,
-    {
-        todo!()
-    }
+impl<Tx> Rpc for Backend<Tx>
+where
+    Tx: Sink<Message, Error = Error> + Unpin + Send,
+{
+    async fn rpc(&self, method: &str, params: &[&str]) -> RpcResult {
+        let id = self.next_id().await;
+        log::info!("RPC {} id: {}", id, method);
 
-    async fn submit<T>(&self, ext: T) -> crate::Result<()>
-    where
-        T: futures_lite::AsyncRead + Send + Unpin,
-    {
-        todo!()
-    }
+        // Store a sender that will notify our receiver when a matching message arrives
+        let (sender, recv) = oneshot::channel::<rpc::Response>();
+        let messages = self.messages.clone();
+        messages.lock().await.insert(id, sender);
 
-    async fn metadata(&self) -> crate::Result<frame_metadata::RuntimeMetadataPrefixed> {
-        todo!()
+        // send rpc request
+        let msg = serde_json::to_string(&rpc::Request {
+            id: id.into(),
+            jsonrpc: Some("2.0"),
+            method,
+            params: &Self::convert_params(params),
+        })
+        .expect("Request is serializable");
+        log::debug!("RPC Request {}", &msg[..20]);
+        let _ = self.tx.lock().await.send(Message::Text(msg)).await;
+
+        // wait for the matching response to arrive
+        let res = recv
+            .await
+            .map_err(|_| standard_error(StandardError::InternalError, None))?
+            .result::<String>()?;
+        log::debug!("RPC Response: {}...", &res[..res.len().min(20)]);
+        let res = hex::decode(&res[2..])
+            .map_err(|_| standard_error(StandardError::InternalError, None))?;
+        Ok(res)
     }
 }
 
-impl Backend {
-    pub async fn new(url: &str) -> Result<Self, crate::Error> {
-        let (connection, _) = connect_async(url)
-            .await
-            .map_err(|_| crate::Error::ChainUnavailable)?;
-        Ok(Backend { connection })
+impl<Tx> Backend<Tx> {
+    async fn next_id(&self) -> Id {
+        self.messages.lock().await.keys().last().unwrap_or(&0) + 1
+    }
+}
+
+type WS2 = futures_util::sink::SinkErrInto<
+    SplitSink<async_tungstenite::WebSocketStream<async_std::net::TcpStream>, Message>,
+    Message,
+    Error,
+>;
+
+impl Backend<WS2> {
+    pub async fn new_ws2(url: &str) -> Result<Self, WsError> {
+        let (stream, _) = async_tungstenite::async_std::connect_async(url).await?;
+        let (tx, rx) = stream.split();
+
+        let backend = Backend {
+            tx: Mutex::new(tx.sink_err_into()),
+            messages: Arc::new(Mutex::new(BTreeMap::new())),
+        };
+
+        backend.process_incoming_messages(rx);
+
+        Ok(backend)
+    }
+
+    fn process_incoming_messages<Rx>(&self, mut rx: Rx)
+    where
+        Rx: Stream<Item = Result<Message, WsError>> + Unpin + Send + 'static,
+    {
+        let messages = self.messages.clone();
+
+        task::spawn(async move {
+            while let Some(msg) = rx.next().await {
+                match msg {
+                    Ok(msg) => {
+                        log::trace!("Got WS message {}", msg);
+                        if let Ok(msg) = msg.to_text() {
+                            let res: rpc::Response =
+                                serde_json::from_str(msg).unwrap_or_else(|_| {
+                                    result_to_response(
+                                        Err(standard_error(StandardError::ParseError, None)),
+                                        ().into(),
+                                    )
+                                });
+                            if res.id.is_u64() {
+                                let id = res.id.as_u64().unwrap() as Id;
+                                log::trace!("Answering request {}", id);
+                                let mut messages = messages.lock().await;
+                                if let Some(channel) = messages.remove(&id) {
+                                    channel.send(res).expect("receiver waiting");
+                                    log::debug!("Answered request id: {}", id);
+                                }
+                            }
+                        }
+                    }
+                    Err(err) => {
+                        log::warn!("WS Error: {}", err);
+                    }
+                }
+            }
+            log::warn!("WS connection closed");
+        });
     }
 }
 
@@ -42,8 +136,9 @@ mod tests {
     use crate::{Backend as _, Error, Sube};
     use once_cell::sync::OnceCell;
 
+    type WSBackend = Backend<WS2>;
     const CHAIN_URL: &str = "ws://localhost:24680";
-    static NODE: OnceCell<Sube<Backend>> = OnceCell::new();
+    static NODE: OnceCell<Sube<WSBackend>> = OnceCell::new();
 
     #[async_std::test]
     async fn get_simple_storage_value() -> Result<(), Error> {
@@ -52,14 +147,18 @@ mod tests {
         let latest_block: u32 = node.query("system/number").await?;
         assert!(latest_block > 0, "Block {} greater than 0", latest_block);
 
-        todo!();
+        Ok(())
     }
 
-    async fn get_node() -> Result<&'static Sube<Backend>, Error> {
+    async fn get_node() -> Result<&'static Sube<WSBackend>, Error> {
         if let Some(node) = NODE.get() {
             return Ok(node);
         }
-        let sube = Backend::new(CHAIN_URL).await?.into();
+        let sube: Sube<_> = Backend::new_ws2(CHAIN_URL)
+            .await
+            .map_err(|_| Error::ChainUnavailable)?
+            .into();
+        sube.try_init_meta().await?;
         NODE.set(sube).map_err(|_| Error::ChainUnavailable)?;
         Ok(NODE.get().unwrap())
     }


### PR DESCRIPTION
- [x] Extracted the common RPC logic to be shared among the HTTP and WS backends. 
- [x] Implement the RPC for websockets using tungstenite
- [ ] Test that it works with metadata v13(only v12 supported initially)